### PR TITLE
Fixed crash in Map Editor with differently sized tilesets

### DIFF
--- a/src/MapEditor/TilePicker.java
+++ b/src/MapEditor/TilePicker.java
@@ -87,6 +87,11 @@ public class TilePicker extends JPanel {
         }
 
         MapTile selectedTile = mapTiles.get(selectedTileIndex);
+        if (selectedTile == null)
+        {
+            selectedTile = mapTiles.get(0);
+            getParent().revalidate();
+        }
         graphicsHandler.drawRectangle(
                 Math.round(selectedTile.getX()) - 2,
                 Math.round(selectedTile.getY()) - 2,


### PR DESCRIPTION
Fixed issue where if you switched between two maps with two differently sized tilesets, and if you had selected a tile with a greater index than the max index of the map you're switching into, it would cause the Map Editor to crash. 

Added an if statement to check if the selectedTileIndex is null. If so, it sets it to 0 and revalidates the scrollbar to properly display the selected tileset.