### PR TITLE
overlaps renamed to touching

### DIFF
--- a/src/EnhancedMapTiles/PushableRock.java
+++ b/src/EnhancedMapTiles/PushableRock.java
@@ -22,7 +22,7 @@ public class PushableRock extends EnhancedMapTile {
     @Override
     public void update(Player player) {
         super.update(player);
-        if (player.overlaps(this) && player.getPlayerState() == PlayerState.WALKING) {
+        if (player.touching(this) && player.getPlayerState() == PlayerState.WALKING) {
             if (player.getCurrentWalkingXDirection() == Direction.LEFT) {
                 if (canMoveLeft(player)) {
                     moveXHandleCollision(-1);

--- a/src/GameObject/AnimatedSprite.java
+++ b/src/GameObject/AnimatedSprite.java
@@ -251,7 +251,7 @@ public class AnimatedSprite implements IntersectableRectangle {
         return currentFrame.intersects(other);
     }
 
-	public boolean overlaps(IntersectableRectangle other) { return currentFrame.overlaps(other); }
+	public boolean touching(IntersectableRectangle other) { return currentFrame.touching(other); }
 
 	public float getAreaOverlapped(IntersectableRectangle other) { return currentFrame.getAreaOverlapped(other); }
 

--- a/src/GameObject/GameObject.java
+++ b/src/GameObject/GameObject.java
@@ -1,6 +1,7 @@
 package GameObject;
 
 import Engine.GraphicsHandler;
+import EnhancedMapTiles.PushableRock;
 import Level.*;
 import Utils.Direction;
 import Utils.ImageUtils;

--- a/src/GameObject/GameObject.java
+++ b/src/GameObject/GameObject.java
@@ -1,7 +1,6 @@
 package GameObject;
 
 import Engine.GraphicsHandler;
-import EnhancedMapTiles.PushableRock;
 import Level.*;
 import Utils.Direction;
 import Utils.ImageUtils;

--- a/src/GameObject/Rectangle.java
+++ b/src/GameObject/Rectangle.java
@@ -187,7 +187,7 @@ public class Rectangle implements IntersectableRectangle {
 				Math.round(intersectRectangle.getY1()) < Math.round(otherIntersectRectangle.getY2() + 1) && Math.round(intersectRectangle.getY2() + 1) > Math.round(otherIntersectRectangle.getY1());
 	}
 
-	// check if this touching or overlapping with another rectangle
+	// check if this is touching (side by side) or overlapping with another rectangle
 	public boolean touching(IntersectableRectangle other) {
 		Rectangle intersectRectangle = getIntersectRectangle();
 		Rectangle otherIntersectRectangle = other.getIntersectRectangle();

--- a/src/GameObject/Rectangle.java
+++ b/src/GameObject/Rectangle.java
@@ -187,8 +187,8 @@ public class Rectangle implements IntersectableRectangle {
 				Math.round(intersectRectangle.getY1()) < Math.round(otherIntersectRectangle.getY2() + 1) && Math.round(intersectRectangle.getY2() + 1) > Math.round(otherIntersectRectangle.getY1());
 	}
 
-	// check if this overlaps with another rectangle
-	public boolean overlaps(IntersectableRectangle other) {
+	// check if this touching or overlapping with another rectangle
+	public boolean touching(IntersectableRectangle other) {
 		Rectangle intersectRectangle = getIntersectRectangle();
 		Rectangle otherIntersectRectangle = other.getIntersectRectangle();
 		return Math.round(intersectRectangle.getX1()) <= Math.round(otherIntersectRectangle.getX2() + 1) && Math.round(intersectRectangle.getX2() + 1) >= Math.round(otherIntersectRectangle.getX1()) &&
@@ -200,7 +200,7 @@ public class Rectangle implements IntersectableRectangle {
 	public float getAreaOverlapped(IntersectableRectangle other) {
 		Rectangle intersectRectangle = getIntersectRectangle();
 		Rectangle otherIntersectRectangle = other.getIntersectRectangle();
-		if (!overlaps(other)) {
+		if (!touching(other)) {
 			return 0;
 		}
 		float width = Math.abs(Math.min(intersectRectangle.getX2() + 1, otherIntersectRectangle.getX2() + 1) - Math.max(intersectRectangle.getX1(), otherIntersectRectangle.getX1()));

--- a/src/Level/EnhancedMapTile.java
+++ b/src/Level/EnhancedMapTile.java
@@ -1,9 +1,6 @@
 package Level;
 
-import java.awt.Color;
 
-import Engine.GraphicsHandler;
-import EnhancedMapTiles.PushableRock;
 import GameObject.GameObject;
 import GameObject.SpriteSheet;
 

--- a/src/Level/EnhancedMapTile.java
+++ b/src/Level/EnhancedMapTile.java
@@ -1,6 +1,9 @@
 package Level;
 
+import java.awt.Color;
+
 import Engine.GraphicsHandler;
+import EnhancedMapTiles.PushableRock;
 import GameObject.GameObject;
 import GameObject.SpriteSheet;
 
@@ -18,10 +21,4 @@ public class EnhancedMapTile extends MapTile {
     public void update(Player player) {
         super.update();
     }
-
-    @Override
-    public void draw(GraphicsHandler graphicsHandler) {
-        super.draw(graphicsHandler);
-    }
-
 }

--- a/src/Level/MapTile.java
+++ b/src/Level/MapTile.java
@@ -269,7 +269,7 @@ public class MapTile extends MapEntity {
     }
 
     @Override
-    public boolean overlaps(IntersectableRectangle other) { return bottomLayer.overlaps(other); }
+    public boolean touching(IntersectableRectangle other) { return bottomLayer.touching(other); }
 
     @Override
     public float getAreaOverlapped(IntersectableRectangle other) { return bottomLayer.getAreaOverlapped(other); }


### PR DESCRIPTION
Renamed the overlaps method in the Rectangle class to "touching" because it's way more accurate -- it actually checks if two rectangles are AT LEAST side by side, and then also if overlapping (as opposed to the intersects method which only checks for an actual overlapping intersection).