### PR TITLE
fixed paint exception that sometimes happens when game is run

### DIFF
--- a/src/Engine/GameLoop.java
+++ b/src/Engine/GameLoop.java
@@ -39,6 +39,7 @@ public class GameLoop {
 
                     if (delta >= 1) {
                         gamePanel.update();
+                        gamePanel.setDoPaint(true);
                         gamePanel.repaint();
                         frames++;
                         delta--;
@@ -82,6 +83,7 @@ public class GameLoop {
                     //Do as many game updates as we need to, potentially playing catchup.
                     while( now - lastUpdateTime > TIME_BETWEEN_UPDATES && updateCount < MAX_UPDATES_BEFORE_RENDER ) {
                         gamePanel.update();
+                        gamePanel.setDoPaint(true);
                         lastUpdateTime += TIME_BETWEEN_UPDATES;
                         updateCount++;
                     }
@@ -103,7 +105,7 @@ public class GameLoop {
                     }
 
                     // Yield until it has been at least the target time between renders. This saves the CPU from hogging.
-                    while ( now - lastRenderTime < TARGET_TIME_BETWEEN_RENDERS && now - lastUpdateTime < TIME_BETWEEN_UPDATES) {
+                    while (now - lastRenderTime < TARGET_TIME_BETWEEN_RENDERS && now - lastUpdateTime < TIME_BETWEEN_UPDATES) {
                         Thread.yield();
 
                         // This stops the app from consuming a ton of CPU/using a ton of power.

--- a/src/Engine/GamePanel.java
+++ b/src/Engine/GamePanel.java
@@ -28,6 +28,7 @@ public class GamePanel extends JPanel {
 	private SpriteFont fpsDisplayLabel;
 	private boolean showFPS = false;
 	private int currentFPS;
+	private boolean doPaint;
 
 	// The JPanel and various important class instances are setup here
 	public GamePanel() {
@@ -56,13 +57,12 @@ public class GamePanel extends JPanel {
 	}
 
 	// this is called later after instantiation, and will initialize screenManager
-	// this had to be done outside of the constructor because it needed to know the JPanel's width and height, which aren't available in the constructor
 	public void setupGame() {
 		setBackground(Colors.CORNFLOWER_BLUE);
 		screenManager.initialize(new Rectangle(getX(), getY(), getWidth(), getHeight()));
 	}
 
-	// this starts the timer (the game loop is started here
+	// this starts the timer (the game loop is started here)
 	public void startGame() {
 		gameLoopProcess.start();
 	}
@@ -73,6 +73,10 @@ public class GamePanel extends JPanel {
 
 	public void setCurrentFPS(int currentFPS) {
 		this.currentFPS = currentFPS;
+	}
+
+	public void setDoPaint(boolean doPaint) {
+		this.doPaint = doPaint;
 	}
 
 	public void update() {
@@ -126,9 +130,11 @@ public class GamePanel extends JPanel {
 	@Override
 	protected void paintComponent(Graphics g) {
 		super.paintComponent(g);
-		// every repaint call will schedule this method to be called
-		// when called, it will setup the graphics handler and then call this class's draw method
-		graphicsHandler.setGraphics((Graphics2D) g);
-		draw();
+		if (doPaint) {
+			// every repaint call will schedule this method to be called
+			// when called, it will setup the graphics handler and then call this class's draw method
+			graphicsHandler.setGraphics((Graphics2D) g);
+			draw();
+		}
 	}
 }


### PR DESCRIPTION
There was a bug that would happen very randomly where if the game's initial update method took a little extra time to run (for whatever reason, IDK) and the JPanel called its async painting too quickly, it would cause an exception to be thrown since it is unable to paint objects that aren't instantiated yet. It didn't crash the game since the paint thread never does, but it was just really annoying since a ten mile long exception at times. This fix ensures the game has run at least one update cycle prior to allowing the JPanel to call the game's draw logic to force it to wait -- not very graceful of a solution but it had to be done this way as I am not using active rendering and instead relying on the JPanel to handle it for me, so I had to work within those limitations. 